### PR TITLE
Allow the latest eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "semver": "^6.3.0"
   },
   "peerDependencies": {
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
   },
   "jest": {
     "coverageReporters": [


### PR DESCRIPTION
Install previously failed on the latest eslint because of peer dependencies